### PR TITLE
edit code-server script

### DIFF
--- a/eksinit-jam.sh
+++ b/eksinit-jam.sh
@@ -109,7 +109,7 @@ echo 'export LBC_CHART_VERSION="1.4.1"' >>  ~/.bash_profile
 .  ~/.bashrc
 
 # Code-server install and run
-curl -fsSL https://code-server.dev/install.sh | sh
+curl -fsSL https://code-server.dev/install.sh | sh | sudo systemctl enable --now code-server@ec2-user | code-server --host 0.0.0.0 --auth none
 
 #cleanup
 #rm -vf ${HOME}/.aws/credentials


### PR DESCRIPTION
Code-server 부분에서 설치 및 실행까지 한번에 수행할 수 있도록 커맨드 명령을 수정하였습니다.

커맨드에 대한 설명은 아래와 같습니다.
- `curl -fsSL https://code-server.dev/install.sh` : code-server 설치를 수행하는 쉘 스크립트를 요청합니다.
- `sh` : 쉘 스크립트를 실행합니다.
- `sudo systemctl enable --now code-server@ec2-user` : 인스턴스가 재부팅 되더라도 systemctl을 통해 code-server가 자동으로 재시작 되도록 합니다.
- `code-server --host 0.0.0.0 --auth none` : code-server 프로세스를 실행합니다. `--host 0.0.0.0` 옵션을 통해 외부로의 접속을 허용합니다. `--auth none` 옵션을 통해 인증 절차를 없애고 바로 vscode를 사용할 수 있도록 합니다.

위의 커맨드로 테스트 해본 결과 정상적으로 code-server에 잘 접속할 수 있었습니다.
![CleanShot 2024-05-29 at 20 37 56@2x](https://github.com/devfloor9/eks-jam-code-snippets/assets/26675063/f60a0025-c823-4981-8c3f-d058189983ed)
