### PR TITLE
Edit code-server install & run command

### DIFF
--- a/eksinit-jam.sh
+++ b/eksinit-jam.sh
@@ -102,9 +102,7 @@ curl -Lo code-server-install.sh https://code-server.dev/install.sh
 chmod +x code-server-install.sh 
 export HOME=/home/ec2-user
 /code-server-install.sh && 
-
-# code-server enable
-sudo systemctl enable --now code-server@ec2-user.service
+sudo systemctl enable --now code-server@ec2-user.service &&
 
 # Replaces "auth: password" with "auth: none" in the code-server config.
 sed -i.bak 's/auth: password/auth: none/' $HOME/.config/code-server/config.yaml

--- a/eksinit-jam.sh
+++ b/eksinit-jam.sh
@@ -97,6 +97,12 @@ echo "alias kgp='kubectl get pods'" | tee -a ~/.bashrc
 echo "alias kgsvc='kubectl get svc'" | tee -a ~/.bashrc
 echo "alias kgn='kubectl get nodes -L beta.kubernetes.io/arch -L eks.amazonaws.com/capacityType -L beta.kubernetes.io/instance-type -L eks.amazonaws.com/nodegroup -L topology.kubernetes.io/zone -L karpenter.sh/provisioner-name -L karpenter.sh/capacity-type'" | tee -a ~/.bashrc
 
+# Install code-server and run(background)
+curl -Lo code-server-install.sh https://code-server.dev/install.sh
+chmod +x code-server-install.sh 
+export HOME=/home/ec2-user
+/code-server-install.sh && code-server --host 0.0.0.0 --auth none > /dev/null 2>&1 &
+
 ######################
 ##  Set Variables  ##
 #####################
@@ -107,9 +113,6 @@ echo 'export LBC_CHART_VERSION="1.4.1"' >>  ~/.bash_profile
 
 .  ~/.bash_profile
 .  ~/.bashrc
-
-# Code-server install and run
-curl -fsSL https://code-server.dev/install.sh | sh | sudo systemctl enable --now code-server@ec2-user | code-server --host 0.0.0.0 --auth none
 
 #cleanup
 #rm -vf ${HOME}/.aws/credentials

--- a/eksinit-jam.sh
+++ b/eksinit-jam.sh
@@ -101,7 +101,25 @@ echo "alias kgn='kubectl get nodes -L beta.kubernetes.io/arch -L eks.amazonaws.c
 curl -Lo code-server-install.sh https://code-server.dev/install.sh
 chmod +x code-server-install.sh 
 export HOME=/home/ec2-user
-/code-server-install.sh && code-server --host 0.0.0.0 --auth none > /dev/null 2>&1 &
+/code-server-install.sh && 
+
+# code-server enable
+sudo systemctl enable --now code-server@ec2-user.service
+
+# Replaces "auth: password" with "auth: none" in the code-server config.
+sed -i.bak 's/auth: password/auth: none/' $HOME/.config/code-server/config.yaml
+
+# Restart code-server
+sudo systemctl restart code-server@ec2-user.service
+
+# -N disables executing a remote shell
+#TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+#INSTANCE_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)
+#ssh -N -L 8080:127.0.0.1:8080 ec2-user@$INSTANCE_IP
+# -N : ssh 연결은 원하지만 원격으로 명령을 실행하고 싶지 않을 때 사용. 리소스 절약 가능.
+# -L : 호스트 포트에서 서버 포트로 연결.
+
+#code-server --host 0.0.0.0 --auth none > /dev/null 2>&1 &
 
 ######################
 ##  Set Variables  ##

--- a/eksinit-jam.sh
+++ b/eksinit-jam.sh
@@ -102,22 +102,16 @@ curl -Lo code-server-install.sh https://code-server.dev/install.sh
 chmod +x code-server-install.sh 
 export HOME=/home/ec2-user
 /code-server-install.sh && 
-sudo systemctl enable --now code-server@ec2-user.service &&
+sudo systemctl enable --now code-server@ec2-user.service
+
+# Wait for creating code-server's config.yaml file
+sleep 10
 
 # Replaces "auth: password" with "auth: none" in the code-server config.
 sed -i.bak 's/auth: password/auth: none/' $HOME/.config/code-server/config.yaml
 
 # Restart code-server
 sudo systemctl restart code-server@ec2-user.service
-
-# -N disables executing a remote shell
-#TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
-#INSTANCE_IP=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/public-ipv4)
-#ssh -N -L 8080:127.0.0.1:8080 ec2-user@$INSTANCE_IP
-# -N : ssh 연결은 원하지만 원격으로 명령을 실행하고 싶지 않을 때 사용. 리소스 절약 가능.
-# -L : 호스트 포트에서 서버 포트로 연결.
-
-#code-server --host 0.0.0.0 --auth none > /dev/null 2>&1 &
 
 ######################
 ##  Set Variables  ##


### PR DESCRIPTION
code-server 설치 및 시작을 위한 커맨드라인 명령을 수정하였습니다.

## 추가 고려해야할 사항(이슈)
하지만 만약 EC2 서버가 재시동되면 code-server 프로세스가 죽는 이슈가 존재합니다.
해당 이슈에 대한 systemd 커맨드를 아래와 같이 작성했지만, 이것을 추가할 경우 code-server가 정상작동하지 않는 이슈가 있어서 우선은 다른 방법을 강구해보려고 합니다. 
```
systemctl enable code-server@ec2-user.service
```

따라서 지금 당장은 만약 EC2를 재시작 할 경우, EC2 쉘에 SSM으로 접속하여 직접 아래의 커맨드라인 명령을 실행해서 code-server를 재시작해주어야 합니다.
```
/code-server-install.sh && code-server --host 0.0.0.0 --auth none > /dev/null 2>&1 &
```